### PR TITLE
Remove homepage product showcase sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 <a class="nav-link active-link" href="index.html">Anasayfa</a>
 <a class="nav-link" href="hakkimizda.html">Hakkımızda</a>
 <div class="relative group">
-<a class="nav-link flex items-center" href="#">Ürünlerimiz <span class="material-icons text-sm ml-1">expand_more</span></a>
+<a class="nav-link flex items-center" href="urunler.html">Ürünlerimiz <span class="material-icons text-sm ml-1">expand_more</span></a>
 <div class="absolute hidden group-hover:block bg-white shadow-lg rounded-md mt-2 py-2 w-48 z-20">
 <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a>
 <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a>
@@ -102,7 +102,7 @@
 </div>
 </div>
 <a class="nav-link" href="#">Blog</a>
-<a class="nav-link" href="iletişim.html">İletişim</a>
+<a class="nav-link" href="iletisim.html">İletişim</a>
 </nav>
 <div class="flex items-center space-x-3 md:space-x-4">
   <button
@@ -119,7 +119,7 @@
   </button>
 
   <a class="hidden md:inline-block px-4 py-2 rounded-md btn-secondary" href="https://masterhijyen.com/">E-KATALOG</a>
-  <a class="hidden md:inline-block px-4 py-2 rounded-md btn-primary font-semibold" href="#">İLETİŞİME GEÇ</a>
+  <a class="hidden md:inline-block px-4 py-2 rounded-md btn-primary font-semibold" href="iletisim.html">İLETİŞİME GEÇ</a>
 </div>
 </div>
 <div class="md:hidden flex justify-center py-2 border-t border-red-500">
@@ -271,111 +271,6 @@
     </div>
   </div>
 </section>
-<section class="bg-gray-100 py-16">
-  <div class="container mx-auto px-4">
-    <div class="flex justify-between items-center mb-6">
-      <h2 class="text-3xl font-semibold">Popüler Ürünlerimiz</h2>
-      <a href="#" class="text-white bg-blue-400 hover:bg-blue-500 px-5 py-2 rounded-full text-sm font-medium transition duration-300">
-        Tümünü Görüntüle →
-      </a>
-    </div>
-
-    <div class="overflow-x-auto pb-4">
-      <div class="flex space-x-6 min-w-max">
-
-        <!-- Ürün Kartı -->
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/plastik-bardak.jpg" alt="Plastik Bardak" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">180 cc Şeffaf Plastik Bardak</p>
-        </div>
-
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/cop-kutusu-50lt.jpg" alt="Çöp Kutusu" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">50 LT Çöp Kutusu</p>
-        </div>
-
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/mobil-cop-kutusu.jpg" alt="Mobil Çöp Kutusu" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">70 LT Mobil Çöp Kutuları</p>
-        </div>
-
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/alky-l103.jpg" alt="Alky" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">Alky L-103</p>
-        </div>
-
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/folyo.jpg" alt="Folyo" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">Alüminyum Folyo Kutusuz 30</p>
-        </div>
-
-      </div>
-    </div>
-  </div>
-</section>
-<section class="bg-gray-100 py-16">
-  <div class="container mx-auto px-4">
-    <div class="bg-[#cde5ec] rounded-xl p-8 lg:p-12 flex flex-col lg:flex-row items-center justify-between gap-6">
-      <div class="lg:w-1/2">
-        <h2 class="text-3xl md:text-4xl font-bold text-white mb-4">
-          Toplu Alımlarda İşletmenize<br/>Özel Efsane Fırsatlar
-        </h2>
-        <p class="text-white text-lg mb-6">
-          Temizlik malzemelerinde toplu alımlara özel %25’e varan indirim fırsatlarını kaçırmayın!
-        </p>
-        <a href="#" class="bg-white text-black font-medium px-6 py-3 rounded-full shadow hover:shadow-lg transition duration-300">
-          Hemen iletişime geç
-        </a>
-      </div>
-      <div class="lg:w-1/2">
-        <img src="https://cdn.egegorsel.com/temizlik-seti.jpg" alt="Toplu Alım Kampanyası" class="rounded-xl w-full object-cover h-64 lg:h-auto">
-      </div>
-    </div>
-  </div>
-</section>
-<section class="bg-gray-100 py-16">
-  <div class="container mx-auto px-4">
-    <div class="flex justify-between items-center mb-6">
-      <h2 class="text-3xl font-semibold">Yeni Ürünler</h2>
-      <a href="#" class="text-white bg-blue-400 hover:bg-blue-500 px-5 py-2 rounded-full text-sm font-medium transition duration-300">
-        Tümünü Görüntüle →
-      </a>
-    </div>
-
-    <div class="overflow-x-auto pb-4">
-      <div class="flex space-x-6 min-w-max">
-
-        <!-- Ürün Kartları -->
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/plastik-bardak.jpg" alt="Plastik Bardak" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">180 cc Şeffaf Plastik Bardak</p>
-        </div>
-
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/cop-kutusu-50lt.jpg" alt="Çöp Kutusu" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">50 LT Çöp Kutusu</p>
-        </div>
-
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/mobil-cop-kutusu.jpg" alt="Mobil Çöp Kutusu" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">70 LT Mobil Çöp Kutuları</p>
-        </div>
-
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/alky-l103.jpg" alt="Alky" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">Alky L-103</p>
-        </div>
-
-        <div class="bg-white rounded-xl shadow p-4 w-56 flex-shrink-0 text-center">
-          <img src="https://cdn.egegorsel.com/folyo.jpg" alt="Folyo" class="w-full h-40 object-contain mb-4">
-          <p class="text-sm font-medium">Alüminyum Folyo Kutusuz 30</p>
-        </div>
-
-      </div>
-    </div>
-  </div>
-</section>
-
 </main>
 <footer class="bg-[#c50000] text-white py-12 mt-16">
   <div class="container mx-auto px-4">
@@ -430,8 +325,8 @@
         <div>
           <h3 class="font-semibold mb-2">Kurumsal</h3>
           <ul class="space-y-1">
-            <li><a href="#" class="hover:underline">Hakkımızda</a></li>
-            <li><a href="#" class="hover:underline">İletişim</a></li>
+            <li><a href="hakkimizda.html" class="hover:underline">Hakkımızda</a></li>
+            <li><a href="iletisim.html" class="hover:underline">İletişim</a></li>
             <li><a href="#" class="hover:underline">Blog</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- remove the Popüler Ürünlerimiz, promotion, and Yeni Ürünler sections from the homepage so the footer follows the product groups grid
- point the desktop Ürünlerimiz nav link, header CTA, and footer Kurumsal entries to their actual pages so visitors can reach the content directly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cee50572a88325b52d25e22aa5cad7