### PR TITLE
Populate product catalog pages with CSV data

### DIFF
--- a/arama.html
+++ b/arama.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Arama | Master Hijyen</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+  <style>
+    body {
+      font-family: 'Poppins', sans-serif;
+      background-color: #ffffff;
+      color: #000000;
+    }
+    .nav-link {
+      position: relative;
+      color: #ffffff;
+    }
+    .nav-link::after {
+      content: '';
+      position: absolute;
+      width: 0;
+      height: 2px;
+      bottom: -5px;
+      left: 50%;
+      transform: translateX(-50%);
+      background-color: #ffffff;
+      transition: width 0.3s ease-in-out;
+    }
+    .nav-link:hover::after {
+      width: 100%;
+    }
+    .active-link::after {
+      width: 100%;
+    }
+  </style>
+</head>
+<body class="bg-white text-black">
+
+<header class="bg-[#c50000] sticky top-0 z-50 shadow-md">
+  <div class="container mx-auto px-4">
+    <div class="flex justify-center items-center py-4">
+      <img alt="Master Hijyen Logo" class="h-12" src="assets/images/masterlogo.png"/>
+    </div>
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between py-2 border-t border-red-500">
+      <nav class="hidden md:flex items-center space-x-8 mx-auto">
+        <a class="nav-link" href="index.html">Anasayfa</a>
+        <a class="nav-link" href="hakkimizda.html">Hakkımızda</a>
+        <div class="relative group">
+          <a class="nav-link flex items-center" href="urunler.html">Ürünlerimiz <span class="material-icons text-sm ml-1">expand_more</span></a>
+          <div class="absolute hidden group-hover:block bg-white shadow-lg rounded-md mt-2 py-2 w-56 z-20">
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kagit.html">Kağıt Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kisiselhijyen.html">Kişisel Hijyen</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="gida.html">Gıda Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a>
+          </div>
+        </div>
+        <a class="nav-link" href="#">Blog</a>
+        <a class="nav-link" href="iletisim.html">İletişim</a>
+      </nav>
+      <div class="flex justify-center md:justify-end items-center space-x-4 mt-4 md:mt-0">
+        <a class="hidden md:inline-block px-4 py-2 rounded-md border border-white text-white" href="https://masterhijyen.com/">E-KATALOG</a>
+        <a class="hidden md:inline-block px-4 py-2 rounded-md bg-white text-[#c50000] font-semibold" href="iletisim.html">İLETİŞİME GEÇ</a>
+      </div>
+    </div>
+  </div>
+</header>
+
+<main class="min-h-[400px] py-12">
+  <div class="container mx-auto px-4 space-y-12">
+    <section class="max-w-3xl mx-auto text-center space-y-6">
+      <div class="space-y-3">
+        <h1 class="text-3xl md:text-4xl font-bold text-gray-900">Ürün Arayın</h1>
+        <p class="text-gray-600 text-sm md:text-base">
+          CSV kataloglarımızdaki karton bardaklardan filtre kahveye kadar tüm ürünleri anahtar kelimeyle arayabilirsiniz.
+          Arama kutusuna ürün kodu, kategori veya ürün adı yazmanız yeterli.
+        </p>
+      </div>
+      <form class="flex flex-col md:flex-row md:items-center gap-3" action="arama.html" method="get">
+        <label class="sr-only" for="searchQuery">Ürün Ara</label>
+        <input id="searchQuery" name="q" type="search" placeholder="Örn: KRT.BRD-7STD veya Nescafé Gold" class="flex-1 rounded-full border border-gray-300 px-5 py-3 focus:border-[#c50000] focus:ring-[#c50000]"/>
+        <button type="submit" class="inline-flex items-center justify-center rounded-full bg-[#c50000] px-6 py-3 text-white font-semibold hover:bg-red-700 transition">Ara</button>
+      </form>
+      <div class="text-left bg-gray-50 border border-gray-200 rounded-2xl p-6 space-y-3">
+        <h2 class="text-lg font-semibold text-gray-900">Hızlı İpuçları</h2>
+        <ul class="list-disc list-inside text-sm text-gray-600 space-y-1">
+          <li>Ürün kodu ile arama yaptığınızda doğrudan ilgili satışı destekleyen ekibimize yönlendirilirsiniz.</li>
+          <li>"Karton bardak", "filtre kahve" veya "şeker" gibi kategori adları ile toplu sonuç listesi görebilirsiniz.</li>
+          <li>Telefon veya e-posta ile arama yaptıktan sonra anında teklif almak için formu doldurun.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+        <div class="space-y-2">
+          <h2 class="text-2xl font-semibold text-[#c50000]">Popüler Kategoriler</h2>
+          <p class="text-gray-600 text-sm md:text-base">Arama yapmak yerine doğrudan ihtiyacınız olan kategoriye ilerleyin.</p>
+        </div>
+        <span class="inline-flex items-center rounded-full bg-green-100 text-green-700 px-4 py-1 text-sm font-medium">CSV verileriyle güncellendi</span>
+      </div>
+      <div class="grid gap-6 md:grid-cols-3">
+        <a class="group border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition" href="kagit.html">
+          <h3 class="text-lg font-semibold text-gray-900 group-hover:text-[#c50000] transition">Kağıt Sanayi Grubu</h3>
+          <p class="text-gray-600 text-sm mt-2">4-12 oz karton bardaklar, tahta karıştırıcılar ve yüksek adetli stok çözümleri.</p>
+        </a>
+        <a class="group border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition" href="gida.html">
+          <h3 class="text-lg font-semibold text-gray-900 group-hover:text-[#c50000] transition">Gıda Grubu</h3>
+          <p class="text-gray-600 text-sm mt-2">Nescafé serisi, Coffee Mate, Çaykur ve Lipton çayları ile şeker çeşitleri.</p>
+        </a>
+        <a class="group border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition" href="kisiselhijyen.html">
+          <h3 class="text-lg font-semibold text-gray-900 group-hover:text-[#c50000] transition">Kişisel Hijyen</h3>
+          <p class="text-gray-600 text-sm mt-2">Dezenfektanlar, sabun sistemleri ve tek kullanımlık koruyucu ürünler.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Sık Aranan Ürünler</h2>
+        <p class="text-gray-600 text-sm md:text-base">CSV dosyamızdan alınan en çok talep gören ürünler hızlı erişim için listelendi.</p>
+      </div>
+      <div class="grid gap-4 md:grid-cols-2">
+        <div class="border border-gray-200 rounded-2xl p-5 bg-white shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900">Karton Bardak Serisi</h3>
+          <ul class="mt-2 text-sm text-gray-600 space-y-1">
+            <li>• KRT.BRD-4 3000 – 4 Oz karton bardak (50 × 60)</li>
+            <li>• KRT.BRD-7STD 3000 – 7 Oz standart bardak (50 × 60)</li>
+            <li>• KRT.BRD-12 2000 – 12 Oz karton bardak (100 × 20)</li>
+          </ul>
+        </div>
+        <div class="border border-gray-200 rounded-2xl p-5 bg-white shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900">Kahve &amp; Beyazlatıcılar</h3>
+          <ul class="mt-2 text-sm text-gray-600 space-y-1">
+            <li>• KHV.NSC-CLS 1000 – Nescafé Classic 1 kg</li>
+            <li>• KHV.NSC-GLD 1000 – Nescafé Gold 100 gr</li>
+            <li>• KHV.NST-MAT 500 – Coffee Mate (5 gr × 100)</li>
+          </ul>
+        </div>
+        <div class="border border-gray-200 rounded-2xl p-5 bg-white shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900">Çay Çözümleri</h3>
+          <ul class="mt-2 text-sm text-gray-600 space-y-1">
+            <li>• AY.CKR-TRY 1000 – Çaykur Tiryaki 1 kg</li>
+            <li>• AY.DGS-TRY 1000 – Doğuş Tiryaki 5 kg</li>
+            <li>• AY.LPT-YLW 32000 – Lipton Demlik Yellow Label</li>
+          </ul>
+        </div>
+        <div class="border border-gray-200 rounded-2xl p-5 bg-white shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900">Şeker ve Tatlandırıcılar</h3>
+          <ul class="mt-2 text-sm text-gray-600 space-y-1">
+            <li>• KR.IRM-SRG 1000 – Irmak Tek Sargılı Küp Şeker</li>
+            <li>• KR.KUP-SRG 1000 – Sargılı Küp Şeker Kolisi</li>
+            <li>• KR.STK-BYZ 4000 – 4 gr stick toz şeker (1000'li)</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Sonuç Bulamadınız mı?</h2>
+        <p class="text-gray-600 text-sm md:text-base">Aradığınız ürün listede yoksa satış ekibimiz yeni ürünleri sisteme eklemeniz için size yardımcı olur.</p>
+      </div>
+      <div class="bg-red-50 border border-red-200 rounded-2xl p-6 md:flex md:items-center md:justify-between gap-6">
+        <div class="space-y-2">
+          <p class="text-gray-600 text-sm md:text-base">CSV kataloğumuz sürekli güncellenir. Talep ettiğiniz ürün için teklif almak üzere bize ulaşın.</p>
+        </div>
+        <div class="flex flex-col sm:flex-row sm:items-center gap-3 text-sm font-semibold text-[#c50000]">
+          <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="tel:+905541406565">0554 140 65 65</a>
+          <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="mailto:dogan@masterhijyen.com">dogan@masterhijyen.com</a>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>
+
+<footer class="bg-[#c50000] text-white py-12 mt-16">
+  <div class="container mx-auto px-4">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+      <div>
+        <img src="assets/images/masterlogo.png" alt="Master Hijyen Logo" class="h-12 mb-4">
+        <p class="text-sm">Aradığınız ürünü bulamadınız mı? Katalog ekibimizle anında iletişime geçebilirsiniz.</p>
+      </div>
+      <div class="grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <h3 class="font-semibold mb-2">Kategorilerimiz</h3>
+          <ul class="space-y-2">
+            <li><a class="hover:underline" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a></li>
+            <li><a class="hover:underline" href="kagit.html">Kağıt Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="kisiselhijyen.html">Kişisel Hijyen</a></li>
+            <li><a class="hover:underline" href="gida.html">Gıda Grubu</a></li>
+            <li><a class="hover:underline" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-semibold mb-2">Kurumsal</h3>
+          <ul class="space-y-1">
+            <li><a class="hover:underline" href="hakkimizda.html">Hakkımızda</a></li>
+            <li><a class="hover:underline" href="iletisim.html">İletişim</a></li>
+            <li><a class="hover:underline" href="#">Blog</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="text-center md:text-right space-y-2">
+        <p class="text-3xl font-bold">4,5<span class="text-lg">/5</span></p>
+        <div class="text-yellow-400">★ ★ ★ ★ ☆</div>
+        <a href="iletisim.html" class="inline-block border border-white text-white px-4 py-2 rounded-full text-sm hover:bg-white hover:text-[#c50000] transition">Hemen Değerlendir</a>
+      </div>
+    </div>
+    <div class="border-t border-white border-opacity-30 mt-8 pt-4 text-center text-sm">
+      Copyright © 2025 Master Hijyen | Tüm hakları saklıdır.
+    </div>
+  </div>
+</footer>
+
+<div class="contact-fab group fixed bottom-5 right-5 z-50">
+  <div class="flex space-x-2 items-center bg-gray-800 text-white px-4 py-2 rounded-full shadow-lg">
+    <a href="tel:+905541406565" class="material-icons" aria-label="Telefon ile ara">call</a>
+    <a href="https://wa.me/905541406565" class="material-icons" aria-label="WhatsApp üzerinden iletişim">whatsapp</a>
+    <a href="mailto:dogan@masterhijyen.com" class="material-icons" aria-label="E-posta gönder">email</a>
+  </div>
+</div>
+
+<script src="main.js"></script>
+</body>
+</html>

--- a/gida.html
+++ b/gida.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Master Hijyen, Temizlik ve Gıda Ürünleri</title>
+  <title>Gıda Grubu | Master Hijyen</title>
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
@@ -34,317 +34,428 @@
     .active-link::after {
       width: 100%;
     }
-    .logo {
-      font-family: 'Brush Script MT', cursive;
-      font-size: 2.5rem;
-      color: #ffffff;
-    }
   </style>
 </head>
 <body class="bg-white text-black">
 
-<!-- Header -->
 <header class="bg-[#c50000] sticky top-0 z-50 shadow-md">
   <div class="container mx-auto px-4">
     <div class="flex justify-center items-center py-4">
-      <img alt="Logo" class="h-12" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDMxkSIRWfwkJKExx_XKDn-NMlljvk4ZEbAylm4btJzoADXsPTgwObjArHHmRv-G_vaCLtfha5ZKgS4wZy8Wym8kgww7Y2oJoo9469884B6rbspz2F8cPSJl_6nq6ViWJw-g5ommdZ0MxeR6j4a2iiQWMDuJwHemNORifX13N-WrxyWh7-M0MKmTvZf3FihxW-dOpprftUWMwQaBEZ2EbofKjo9XlEsIJj8W67eR9K4hc-IO8nyDJZ1KZR65XMZO6eZq0-CpfkWDR5C"/>
+      <img alt="Master Hijyen Logo" class="h-12" src="assets/images/masterlogo.png"/>
     </div>
-    <div class="flex justify-between items-center py-2 border-t border-red-500">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between py-2 border-t border-red-500">
       <nav class="hidden md:flex items-center space-x-8 mx-auto">
-<a class="nav-link active-link" href="index.html">Anasayfa</a>
-<a class="nav-link" href="hakkimizda.html">Hakkımızda</a>
-<div class="relative group">
-<a class="nav-link flex items-center" href="#">Ürünlerimiz <span class="material-icons text-sm ml-1">expand_more</span></a>
-<div class="absolute hidden group-hover:block bg-white shadow-lg rounded-md mt-2 py-2 w-48 z-20">
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kagit.html">Kağıt Sanayi Grubu</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kisiselhijyen.html">Kişisel Hijyen</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="gida.html">Gıda Grubu</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a>
-</div>
-</div>
-<a class="nav-link" href="#">Blog</a>
-<a class="nav-link" href="iletisim.html">İletişim</a>
-</nav>
-      <div class="flex items-center space-x-4">
-        <a class="hidden md:inline-block px-4 py-2 rounded-md border border-white text-white" href="#">E-KATALOG</a>
-        <a class="hidden md:inline-block px-4 py-2 rounded-md bg-white text-[#c50000] font-semibold" href="#">İLETİŞİME GEÇ</a>
+        <a class="nav-link" href="index.html">Anasayfa</a>
+        <a class="nav-link" href="hakkimizda.html">Hakkımızda</a>
+        <div class="relative group">
+          <a class="nav-link flex items-center" href="urunler.html">Ürünlerimiz <span class="material-icons text-sm ml-1">expand_more</span></a>
+          <div class="absolute hidden group-hover:block bg-white shadow-lg rounded-md mt-2 py-2 w-56 z-20">
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kagit.html">Kağıt Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kisiselhijyen.html">Kişisel Hijyen</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="gida.html">Gıda Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a>
+          </div>
+        </div>
+        <a class="nav-link" href="#">Blog</a>
+        <a class="nav-link" href="iletisim.html">İletişim</a>
+      </nav>
+      <div class="flex justify-center md:justify-end items-center space-x-4 mt-4 md:mt-0">
+        <a class="hidden md:inline-block px-4 py-2 rounded-md border border-white text-white" href="https://masterhijyen.com/">E-KATALOG</a>
+        <a class="hidden md:inline-block px-4 py-2 rounded-md bg-white text-[#c50000] font-semibold" href="iletisim.html">İLETİŞİME GEÇ</a>
       </div>
     </div>
   </div>
 </header>
 
-<!-- MAIN Content Area (Her sayfada burayı dolduracaksın) -->
 <main class="min-h-[400px] py-12">
-  <div class="container mx-auto px-4">
-    <div class="max-w-3xl mx-auto text-center">
-      <h1 class="text-3xl md:text-4xl font-bold text-[#c50000] mb-4">Gıda Grubu Ürünleri</h1>
-      <p class="text-base md:text-lg text-gray-600">
-        Sıcak içecek servisinden kahve deneyimine kadar günlük tüketim ihtiyaçlarınız için özenle seçtiğimiz ürünleri kategoriler halinde inceleyebilirsiniz.
+  <div class="container mx-auto px-4 space-y-12">
+    <div class="max-w-3xl mx-auto text-center space-y-4">
+      <span class="inline-flex items-center justify-center rounded-full bg-red-100 text-[#c50000] px-3 py-1 text-sm font-medium">Sıcak içecek ikram çözümleri</span>
+      <h1 class="text-3xl md:text-4xl font-bold text-gray-900">Gıda Grubu</h1>
+      <p class="text-gray-600 text-sm md:text-base">
+        Ofislerden otellere, üretim tesislerinden sosyal alanlara kadar geniş bir yelpazeye hitap eden çay, kahve, şeker ve tamamlayıcı ürün portföyümüz ile ikram süreçlerini hızlandırıyoruz.
+        CSV listelerimizden derlenen ürünler; standardize gramaj, hijyenik ambalaj ve kolay stok yönetimi sağlar.
       </p>
     </div>
 
-    <div class="space-y-16 mt-12">
-      <!-- Tek Kullanımlık Karton Bardaklar -->
-      <section>
-        <div class="max-w-4xl mb-8">
-          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Tek Kullanımlık Karton Bardaklar</h2>
-          <p class="text-gray-600 text-sm md:text-base">
-            Sıcak ve soğuk içecekler için farklı ebat seçenekleri sunan karton bardak çeşitlerimizle servis süreçlerinizi hızlandırın.
-          </p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 4 oz (50 Adet x 60 Paket)</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 6,5 oz (50 Adet x 40 Paket)</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 7 oz Standart (50 Adet x 40 Paket)</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 7 oz Standart (50 Adet x 30 Paket)</h3>
-            </div>
-          </a>
-        </div>
-      </section>
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Şeker ve Tatlandırıcılar</h2>
+        <p class="text-gray-600 text-sm md:text-base">
+          Bireysel servisler için tek tek sarılı küp şekerlerden yoğun tüketime uygun kolili çözümlere kadar geniş bir seçenek sunuyoruz.
+        </p>
+      </div>
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-[#c50000] text-white">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün Kodu</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ambalaj</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Birim</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">KDV</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Liste Fiyatı</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KR.IRM-SRG 1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Irmak Tek Sargılı Küp Şeker</p>
+                <p class="text-gray-600 text-sm">Hijyenik tekli paketler, toplantı servisleri için ideal</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">500 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺45,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KR.KUP-SRG 1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Sargılı Küp Şeker</p>
+                <p class="text-gray-600 text-sm">Kolili 1000 adet, yoğun tüketim noktalarına uygun</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">5000 gr</td>
+              <td class="px-4 py-3 text-gray-700">Kol</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺300,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KR.STK-BYZ 4000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Beyaz Stick Toz Şeker</p>
+                <p class="text-gray-600 text-sm">4 gr × 1000 adet; pratik self-servis alanları için</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">4000 gr</td>
+              <td class="px-4 py-3 text-gray-700">Kol</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺320,00</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="text-xs text-gray-500">Fiyatlar liste fiyatıdır; düzenli sevkiyat gereksinimlerine özel teklif çalışılır.</p>
+    </section>
 
-      <!-- Şeker ve Karıştırıcılar -->
-      <section>
-        <div class="max-w-4xl mb-8">
-          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Şeker ve Karıştırıcılar</h2>
-          <p class="text-gray-600 text-sm md:text-base">
-            Kahve ve çay servislerine eşlik eden şeker ve karıştırıcı seçeneklerimizi ihtiyacınıza göre kolayca seçin.
-          </p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Tatlı Kaşığı 1000'li Paket</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Irmak Tek Sargılı Küp Şeker</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Sargılı Küp Şeker</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Sargısız Küp Şeker</h3>
-            </div>
-          </a>
-        </div>
-      </section>
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Filtre Kahve ve Hazırlık Ekipmanları</h2>
+        <p class="text-gray-600 text-sm md:text-base">
+          Kahve makineleri ile tam uyumlu filtre kağıdı ve taze öğütülmüş filtre kahve seçeneklerimizle profesyonel sunumlar kolaylaşır.
+        </p>
+      </div>
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-[#c50000] text-white">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün Kodu</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ambalaj</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Birim</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">KDV</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Liste Fiyatı</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KHV.FLT-KGD 100</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Coffee Time Filtre Kahve Kağıdı No:4</p>
+                <p class="text-gray-600 text-sm">40 adetlik paket, yoğun servis ritmine dayanıklı</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">40 adet</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺35,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KHV.FLT-COL 1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Filtre Kahve Colomba</p>
+                <p class="text-gray-600 text-sm">Zengin aroma, profesyonel demleme makineleri için</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">500 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺385,00</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-      <!-- Kahve ve Demleme Ürünleri -->
-      <section>
-        <div class="max-w-4xl mb-8">
-          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Kahve ve Demleme Ürünleri</h2>
-          <p class="text-gray-600 text-sm md:text-base">
-            Ofis ve işletmelerin favorisi olan kahveler, kahve kreması ve demleme ekipmanlarımızı keşfedin.
-          </p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Nescafé Classic 1000 g Paket</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Filtre Kahve Colombia</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Coffee Time Filtre Kahve Kağıdı No:4</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Nescafé Coffee Mate 400 g</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Nescafé Classic Çözünebilir Kahve 100 g</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Nescafé Gold 100 g</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Mehmet Efendi Türk Kahvesi 100 g</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Mehmet Efendi Türk Kahvesi 250 g</h3>
-            </div>
-          </a>
-        </div>
-      </section>
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Çay Çeşitleri</h2>
+        <p class="text-gray-600 text-sm md:text-base">
+          Dökme çaydan demlik poşete kadar farklı demleme alışkanlıklarına uygun seçeneklerimizle servis tutarlılığı sağlıyoruz.
+        </p>
+      </div>
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-[#c50000] text-white">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün Kodu</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ambalaj</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Birim</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">KDV</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Liste Fiyatı</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">AY.CKR-TRY 1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Çaykur Tiryaki Dökme Çay</p>
+                <p class="text-gray-600 text-sm">Klasik harman, 1 kg vakumlu paket</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">1000 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺245,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">AY.CKR-TRY 2000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Çaykur Tiryaki Dökme Çay</p>
+                <p class="text-gray-600 text-sm">2 kg ekonomik paket, yüksek tüketim için</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">2000 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺500,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">AY.CKR-TMR 125</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Çaykur Tomurcuk Çay</p>
+                <p class="text-gray-600 text-sm">Demlikte aroma güçlendirmek için 125 gr özel harman</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">125 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺65,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">AY.DGS-TRY 1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Doğuş Tiryaki Dökme Çay</p>
+                <p class="text-gray-600 text-sm">5 kg kolili seçenek, yemekhaneler için</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">5000 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺1.100,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">AY.LPT-YLW 32000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Lipton Demlik Yellow Label</p>
+                <p class="text-gray-600 text-sm">100'lü demlik poşet × 16 paket, standart tat</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">16 paket</td>
+              <td class="px-4 py-3 text-gray-700">Kol</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺2.200,00</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
 
-      <!-- Çay Çeşitleri -->
-      <section>
-        <div class="max-w-4xl mb-8">
-          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Çay Çeşitleri</h2>
-          <p class="text-gray-600 text-sm md:text-base">
-            Dökme ve poşet seçenekleriyle demleme alışkanlıklarınıza uygun çayları keşfedin.
-          </p>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Çaykur Tiryaki Dökme Çay 1 Kg</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Çaykur Tiryaki Dökme Çay 1 Kg (Alternatif Paket)</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Çaykur Tiryaki Dökme Çay 500 g</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Doğuş Tiryaki Dökme Çay 1 Kg</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Doğuş Tiryaki Dökme Çay 500 g</h3>
-            </div>
-          </a>
-          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
-            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
-            <div class="p-4">
-              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Lipton Delight Yellow Label (100'lü)</h3>
-            </div>
-          </a>
-        </div>
-      </section>
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Hazır Kahveler ve Beyazlatıcılar</h2>
+        <p class="text-gray-600 text-sm md:text-base">
+          Self-servis alanlarında aynı tada ulaşmak için paketli kahve ve beyazlatıcı çözümlerini tek kaynaktan sunuyoruz.
+        </p>
+      </div>
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-[#c50000] text-white">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün Kodu</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ambalaj</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Birim</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">KDV</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Liste Fiyatı</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KHV.NST-BYZ 1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Nestlé Coffee Mate Kahve Beyazlatıcı</p>
+                <p class="text-gray-600 text-sm">400 gr ekonomik paket, kremamsı lezzet</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">400 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺220,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KHV.NSC-CLS 1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Nescafé Classic</p>
+                <p class="text-gray-600 text-sm">1 kg endüstriyel paket, yüksek servis hacmi için</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">1000 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺2.200,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KHV.NSC-CLS 200</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Nescafé Classic</p>
+                <p class="text-gray-600 text-sm">200 gr paket, küçük ofis kullanımlarına uygun</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">200 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺290,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KHV.NSC-GLD 1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Nescafé Gold</p>
+                <p class="text-gray-600 text-sm">100 gr premium granül kahve</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">100 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺230,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KHV.NST-MAT 500</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Nestlé Coffee Mate (5 gr × 100)</p>
+                <p class="text-gray-600 text-sm">Tek porsiyon paket, yüksek hijyen standardı</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">500 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺245,00</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Türk Kahvesi Seçenekleri</h2>
+        <p class="text-gray-600 text-sm md:text-base">
+          Geleneksel damak tadı için Mehmet Efendi markasının farklı gramajlarını stoklarımızda bulunduruyoruz.
+        </p>
+      </div>
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-[#c50000] text-white">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün Kodu</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ambalaj</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Birim</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">KDV</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Liste Fiyatı</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KHV.MEF-TRK 1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Mehmet Efendi Türk Kahvesi</p>
+                <p class="text-gray-600 text-sm">100 gr vakumlu paket, taze öğütülmüş</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">100 gr</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺80,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KHV.MEF-TRK 72</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Mehmet Efendi Türk Kahvesi</p>
+                <p class="text-gray-600 text-sm">12 × 6 gr stick; minibar ve oda ikramları için</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">72 gr</td>
+              <td class="px-4 py-3 text-gray-700">Kol</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺85,00</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <div class="bg-red-50 border border-red-200 rounded-2xl p-6 md:flex md:items-center md:justify-between gap-6">
+      <div class="space-y-2">
+        <h3 class="text-xl font-semibold text-[#c50000]">İkram noktalarınız için tek elden tedarik</h3>
+        <p class="text-gray-600 text-sm md:text-base">
+          CSV listesinde yer alan tüm ürünler düzenli stoklarımızda bulunur. Otomatik sipariş, konsinye ve özel marka talepleri için satış ekibimiz destek verir.
+        </p>
+      </div>
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3 text-sm font-semibold text-[#c50000]">
+        <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="tel:+905541406565">0554 140 65 65</a>
+        <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="mailto:dogan@masterhijyen.com">dogan@masterhijyen.com</a>
+      </div>
     </div>
   </div>
 </main>
 
-<!-- Footer -->
 <footer class="bg-[#c50000] text-white py-12 mt-16">
   <div class="container mx-auto px-4">
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
       <div>
-        <img src="https://cdn.egegorsel.com/ege-hijyen-logo-white.png" alt="Ege Hijyen Logo" class="h-12 mb-4">
-        <p class="text-sm">Kaliteli ve güvenilir temizlik malzemeleriyle hijyenik çözümler sunuyoruz</p>
+        <img src="assets/images/masterlogo.png" alt="Master Hijyen Logo" class="h-12 mb-4">
+        <p class="text-sm">Sıcak içecek ikramında kalite ve süreklilik sağlayan ürün portföyü sunuyoruz.</p>
       </div>
       <div class="grid grid-cols-2 gap-4 text-sm">
         <div>
           <h3 class="font-semibold mb-2">Kategorilerimiz</h3>
-          <ul class="space-y-1">
-            <li><a href="#" class="hover:underline">Temizlik Grubu</a></li>
-            <li><a href="#" class="hover:underline">Gıda Grubu</a></li>
-            <li><a href="#" class="hover:underline">Kırtasiye Grubu</a></li>
+          <ul class="space-y-2">
+            <li><a class="hover:underline" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a></li>
+            <li><a class="hover:underline" href="kagit.html">Kağıt Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="kisiselhijyen.html">Kişisel Hijyen</a></li>
+            <li><a class="hover:underline" href="gida.html">Gıda Grubu</a></li>
+            <li><a class="hover:underline" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a></li>
           </ul>
         </div>
         <div>
           <h3 class="font-semibold mb-2">Kurumsal</h3>
-          <ul class="space-y-2">
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="hijyensanayigrubu.html">
-      Hijyen Sanayi Grubu
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="temizlikurunlerigrubu.html">
-      Temizlik Ürünleri Grubu
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="kagıtsanayi.html">
-      Kağıt Sanayi Grubu
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="kisiselhijyen.html">
-      Kişisel Hijyen
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="gida.html">
-      Gıda Grubu
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="profhijyen.html">
-      Profesyonel Hijyen Ekipmanları
-    </a>
-  </li>
-</ul>
-
+          <ul class="space-y-1">
+            <li><a class="hover:underline" href="hakkimizda.html">Hakkımızda</a></li>
+            <li><a class="hover:underline" href="iletisim.html">İletişim</a></li>
+            <li><a class="hover:underline" href="#">Blog</a></li>
+          </ul>
         </div>
       </div>
-      <div class="text-center md:text-right">
+      <div class="text-center md:text-right space-y-2">
         <p class="text-3xl font-bold">4,5<span class="text-lg">/5</span></p>
-        <div class="text-yellow-400 mb-2">★ ★ ★ ★ ☆</div>
-        <a href="#" class="inline-block border border-white text-white px-4 py-2 rounded-full text-sm hover:bg-white hover:text-[#c50000] transition">
-          Hemen Değerlendir
-        </a>
+        <div class="text-yellow-400">★ ★ ★ ★ ☆</div>
+        <a href="iletisim.html" class="inline-block border border-white text-white px-4 py-2 rounded-full text-sm hover:bg-white hover:text-[#c50000] transition">Hemen Değerlendir</a>
       </div>
     </div>
     <div class="border-t border-white border-opacity-30 mt-8 pt-4 text-center text-sm">
-      Copyright © 2025 Ege Hijyen | Tüm hakları saklıdır.
+      Copyright © 2025 Master Hijyen | Tüm hakları saklıdır.
     </div>
   </div>
 </footer>
 
-<!-- Sabit iletişim butonları (mevcut kodundaki) -->
 <div class="contact-fab group fixed bottom-5 right-5 z-50">
   <div class="flex space-x-2 items-center bg-gray-800 text-white px-4 py-2 rounded-full shadow-lg">
-    <a href="#" class="material-icons">call</a>
-    <a href="#" class="material-icons">whatsapp</a>
-    <a href="#" class="material-icons">email</a>
+    <a href="tel:+905541406565" class="material-icons" aria-label="Telefon ile ara">call</a>
+    <a href="https://wa.me/905541406565" class="material-icons" aria-label="WhatsApp üzerinden iletişim">whatsapp</a>
+    <a href="mailto:dogan@masterhijyen.com" class="material-icons" aria-label="E-posta gönder">email</a>
   </div>
 </div>
-<script  src="main.js"> </script>
+
+<script src="main.js"></script>
 </body>
 </html>

--- a/kagit.html
+++ b/kagit.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Master Hijyen, Temizlik ve Gıda Ürünleri</title>
+  <title>Kağıt Sanayi Grubu | Master Hijyen</title>
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
@@ -34,130 +34,249 @@
     .active-link::after {
       width: 100%;
     }
-    .logo {
-      font-family: 'Brush Script MT', cursive;
-      font-size: 2.5rem;
-      color: #ffffff;
-    }
   </style>
 </head>
 <body class="bg-white text-black">
 
-<!-- Header -->
 <header class="bg-[#c50000] sticky top-0 z-50 shadow-md">
   <div class="container mx-auto px-4">
     <div class="flex justify-center items-center py-4">
-      <img alt="Logo" class="h-12" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDMxkSIRWfwkJKExx_XKDn-NMlljvk4ZEbAylm4btJzoADXsPTgwObjArHHmRv-G_vaCLtfha5ZKgS4wZy8Wym8kgww7Y2oJoo9469884B6rbspz2F8cPSJl_6nq6ViWJw-g5ommdZ0MxeR6j4a2iiQWMDuJwHemNORifX13N-WrxyWh7-M0MKmTvZf3FihxW-dOpprftUWMwQaBEZ2EbofKjo9XlEsIJj8W67eR9K4hc-IO8nyDJZ1KZR65XMZO6eZq0-CpfkWDR5C"/>
+      <img alt="Master Hijyen Logo" class="h-12" src="assets/images/masterlogo.png"/>
     </div>
-    <div class="flex justify-between items-center py-2 border-t border-red-500">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between py-2 border-t border-red-500">
       <nav class="hidden md:flex items-center space-x-8 mx-auto">
-<a class="nav-link active-link" href="index.html">Anasayfa</a>
-<a class="nav-link" href="hakkimizda.html">Hakkımızda</a>
-<div class="relative group">
-<a class="nav-link flex items-center" href="#">Ürünlerimiz <span class="material-icons text-sm ml-1">expand_more</span></a>
-<div class="absolute hidden group-hover:block bg-white shadow-lg rounded-md mt-2 py-2 w-48 z-20">
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kagit.html">Kağıt Sanayi Grubu</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kisiselhijyen.html">Kişisel Hijyen</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="gida.html">Gıda Grubu</a>
-<a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a>
-</div>
-</div>
-<a class="nav-link" href="#">Blog</a>
-<a class="nav-link" href="iletisim.html">İletişim</a>
-</nav>
-      <div class="flex items-center space-x-4">
-        <a class="hidden md:inline-block px-4 py-2 rounded-md border border-white text-white" href="#">E-KATALOG</a>
-        <a class="hidden md:inline-block px-4 py-2 rounded-md bg-white text-[#c50000] font-semibold" href="#">İLETİŞİME GEÇ</a>
+        <a class="nav-link" href="index.html">Anasayfa</a>
+        <a class="nav-link" href="hakkimizda.html">Hakkımızda</a>
+        <div class="relative group">
+          <a class="nav-link flex items-center" href="urunler.html">Ürünlerimiz <span class="material-icons text-sm ml-1">expand_more</span></a>
+          <div class="absolute hidden group-hover:block bg-white shadow-lg rounded-md mt-2 py-2 w-56 z-20">
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kagit.html">Kağıt Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kisiselhijyen.html">Kişisel Hijyen</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="gida.html">Gıda Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a>
+          </div>
+        </div>
+        <a class="nav-link" href="#">Blog</a>
+        <a class="nav-link" href="iletisim.html">İletişim</a>
+      </nav>
+      <div class="flex justify-center md:justify-end items-center space-x-4 mt-4 md:mt-0">
+        <a class="hidden md:inline-block px-4 py-2 rounded-md border border-white text-white" href="https://masterhijyen.com/">E-KATALOG</a>
+        <a class="hidden md:inline-block px-4 py-2 rounded-md bg-white text-[#c50000] font-semibold" href="iletisim.html">İLETİŞİME GEÇ</a>
       </div>
     </div>
   </div>
 </header>
 
-<!-- MAIN Content Area (Her sayfada burayı dolduracaksın) -->
 <main class="min-h-[400px] py-12">
-  <div class="container mx-auto px-4">
-    <!-- 🔽 Buraya her sayfa için özel içerik gelecek -->
+  <div class="container mx-auto px-4 space-y-12">
+    <div class="max-w-3xl mx-auto text-center space-y-4">
+      <span class="inline-flex items-center justify-center rounded-full bg-red-100 text-[#c50000] px-3 py-1 text-sm font-medium">Tek kullanımlık servis çözümleri</span>
+      <h1 class="text-3xl md:text-4xl font-bold text-gray-900">Kağıt Sanayi Grubu</h1>
+      <p class="text-gray-600 text-sm md:text-base">
+        Sıcak içecek servislerinde kullanılan karton bardak ve karıştırıcı ürünlerimiz, yoğun kullanım alanlarında dayanıklılık ve hijyeni bir arada sunar.
+        Farklı hacim ve gramaj seçenekleri sayesinde ofisler, kafe zincirleri ve endüstriyel yemek alanları için ideal çözümler sağlarız.
+      </p>
+    </div>
+
+    <section class="space-y-6">
+      <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+        <div class="space-y-2">
+          <h2 class="text-2xl font-semibold text-[#c50000]">Karton Bardak Koleksiyonu</h2>
+          <p class="text-gray-600 text-sm md:text-base">
+            4 oz'dan 12 oz'a kadar uzanan bardaklarımız kalın karton yapısı ve kontrollü gramajı ile sıcak içecek servislerinde formunu korur.
+            Tüm seçenekler stoktan hızlı teslim avantajı ile sunulur.
+          </p>
+        </div>
+        <span class="inline-flex items-center rounded-full bg-green-100 text-green-700 px-4 py-1 text-sm font-medium">Her zaman stokta</span>
+      </div>
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-[#c50000] text-white">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün Kodu</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Gramaj</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Birim</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">KDV</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Liste Fiyatı</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KRT.BRD-4 3000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Karton Bardak 4 Oz</p>
+                <p class="text-gray-600 text-sm">50 adet × 60 paket</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">2,5 gr</td>
+              <td class="px-4 py-3 text-gray-700">Kol</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺900,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KRT.BRD-6 3000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Karton Bardak 6 Oz</p>
+                <p class="text-gray-600 text-sm">50 adet × 60 paket</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">3,3 gr</td>
+              <td class="px-4 py-3 text-gray-700">Kol</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺950,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KRT.BRD-7STD 3000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Karton Bardak 7 Oz Standart</p>
+                <p class="text-gray-600 text-sm">50 adet × 60 paket</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">3,6 gr</td>
+              <td class="px-4 py-3 text-gray-700">Kol</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺1.000,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KRT.BRD-8 2000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Karton Bardak 8 Oz</p>
+                <p class="text-gray-600 text-sm">50 adet × 40 paket</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">5,7 gr</td>
+              <td class="px-4 py-3 text-gray-700">Kol</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺1.500,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KRT.BRD-12 2000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Karton Bardak 12 Oz</p>
+                <p class="text-gray-600 text-sm">100 adet × 20 paket</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">6,5 gr</td>
+              <td class="px-4 py-3 text-gray-700">Kol</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺1.650,00</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="text-xs text-gray-500">Belirtilen liste fiyatları KDV hariçtir ve toplu alımlarda özel teklif sunulur.</p>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Karıştırıcı ve Servis Aksesuarları</h2>
+        <p class="text-gray-600 text-sm md:text-base">
+          Karton bardak servislerinde tamamlayıcı aksesuarlarımız, tek tek paketlenmiş yapıları sayesinde hijyeni korur ve hızlı servisi destekler.
+        </p>
+      </div>
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-[#c50000] text-white">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün Kodu</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ambalaj</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Birim</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">KDV</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Liste Fiyatı</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KRS.THT-500</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Tahta Karıştırıcı</p>
+                <p class="text-gray-600 text-sm">500'lü paket, tek kullanımlık</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">500 adet</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺80,00</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">KRS.THT-1000</td>
+              <td class="px-4 py-3">
+                <p class="font-medium text-gray-900">Tahta Karıştırıcı</p>
+                <p class="text-gray-600 text-sm">1000'li paket, ekstra stok</p>
+              </td>
+              <td class="px-4 py-3 text-gray-700">1000 adet</td>
+              <td class="px-4 py-3 text-gray-700">Paket</td>
+              <td class="px-4 py-3 text-gray-700">%20</td>
+              <td class="px-4 py-3 font-semibold text-gray-900">₺140,00</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="text-xs text-gray-500">Ambalajlar kraft kutularla sevk edilir, talebe göre özel baskı seçenekleri sunulur.</p>
+    </section>
+
+    <div class="bg-red-50 border border-red-200 rounded-2xl p-6 md:flex md:items-center md:justify-between gap-6">
+      <div class="space-y-2">
+        <h3 class="text-xl font-semibold text-[#c50000]">Barista servislerinizi kişiselleştirelim</h3>
+        <p class="text-gray-600 text-sm md:text-base">
+          Markanıza özel bardak baskıları, farklı gramaj seçenekleri ve sürekli stok garantisi için satış ekibimizle iletişime geçin.
+          Özel projelerde numune gönderimi ve hızlı teklif desteği sağlıyoruz.
+        </p>
+      </div>
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3 text-sm font-semibold text-[#c50000]">
+        <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="tel:+905541406565">0554 140 65 65</a>
+        <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="mailto:dogan@masterhijyen.com">dogan@masterhijyen.com</a>
+      </div>
+    </div>
   </div>
 </main>
 
-<!-- Footer -->
 <footer class="bg-[#c50000] text-white py-12 mt-16">
   <div class="container mx-auto px-4">
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
       <div>
-        <img src="https://cdn.egegorsel.com/ege-hijyen-logo-white.png" alt="Ege Hijyen Logo" class="h-12 mb-4">
-        <p class="text-sm">Kaliteli ve güvenilir temizlik malzemeleriyle hijyenik çözümler sunuyoruz</p>
+        <img src="assets/images/masterlogo.png" alt="Master Hijyen Logo" class="h-12 mb-4">
+        <p class="text-sm">Tek kullanımlık servis ekipmanlarında kaliteli ve hijyenik çözümler sunuyoruz.</p>
       </div>
       <div class="grid grid-cols-2 gap-4 text-sm">
         <div>
           <h3 class="font-semibold mb-2">Kategorilerimiz</h3>
-          <ul class="space-y-1">
-            <li><a href="#" class="hover:underline">Hijyen Sanayi Grubu</a></li>
-            <li><a href="#" class="hover:underline">Gıda Grubu</a></li>
-            <li><a href="#" class="hover:underline">Kırtasiye Grubu</a></li>
+          <ul class="space-y-2">
+            <li><a class="hover:underline" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a></li>
+            <li><a class="hover:underline" href="kagit.html">Kağıt Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="kisiselhijyen.html">Kişisel Hijyen</a></li>
+            <li><a class="hover:underline" href="gida.html">Gıda Grubu</a></li>
+            <li><a class="hover:underline" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a></li>
           </ul>
         </div>
         <div>
           <h3 class="font-semibold mb-2">Kurumsal</h3>
-          <ul class="space-y-2">
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="hijyensanayigrubu.html">
-      Hijyen Sanayi Grubu
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="temizlikurunlerigrubu.html">
-      Temizlik Ürünleri Grubu
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="kagıtsanayi.html">
-      Kağıt Sanayi Grubu
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="kisiselhijyen.html">
-      Kişisel Hijyen
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="gida.html">
-      Gıda Grubu
-    </a>
-  </li>
-  <li>
-    <a class="block px-4 py-2 text-sm text-white hover:bg-gray-300" href="profhijyen.html">
-      Profesyonel Hijyen Ekipmanları
-    </a>
-  </li>
-</ul>
-
+          <ul class="space-y-1">
+            <li><a class="hover:underline" href="hakkimizda.html">Hakkımızda</a></li>
+            <li><a class="hover:underline" href="iletisim.html">İletişim</a></li>
+            <li><a class="hover:underline" href="#">Blog</a></li>
+          </ul>
         </div>
       </div>
-      <div class="text-center md:text-right">
+      <div class="text-center md:text-right space-y-2">
         <p class="text-3xl font-bold">4,5<span class="text-lg">/5</span></p>
-        <div class="text-yellow-400 mb-2">★ ★ ★ ★ ☆</div>
-        <a href="#" class="inline-block border border-white text-white px-4 py-2 rounded-full text-sm hover:bg-white hover:text-[#c50000] transition">
-          Hemen Değerlendir
-        </a>
+        <div class="text-yellow-400">★ ★ ★ ★ ☆</div>
+        <a href="iletisim.html" class="inline-block border border-white text-white px-4 py-2 rounded-full text-sm hover:bg-white hover:text-[#c50000] transition">Hemen Değerlendir</a>
       </div>
     </div>
     <div class="border-t border-white border-opacity-30 mt-8 pt-4 text-center text-sm">
-      Copyright © 2025 Ege Hijyen | Tüm hakları saklıdır.
+      Copyright © 2025 Master Hijyen | Tüm hakları saklıdır.
     </div>
   </div>
 </footer>
 
-<!-- Sabit iletişim butonları (mevcut kodundaki) -->
 <div class="contact-fab group fixed bottom-5 right-5 z-50">
   <div class="flex space-x-2 items-center bg-gray-800 text-white px-4 py-2 rounded-full shadow-lg">
-    <a href="#" class="material-icons">call</a>
-    <a href="#" class="material-icons">whatsapp</a>
-    <a href="#" class="material-icons">email</a>
+    <a href="tel:+905541406565" class="material-icons" aria-label="Telefon ile ara">call</a>
+    <a href="https://wa.me/905541406565" class="material-icons" aria-label="WhatsApp üzerinden iletişim">whatsapp</a>
+    <a href="mailto:dogan@masterhijyen.com" class="material-icons" aria-label="E-posta gönder">email</a>
   </div>
 </div>
+
 <script src="main.js"></script>
 </body>
 </html>

--- a/kisiselhijyen.html
+++ b/kisiselhijyen.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Kişisel Hijyen | Master Hijyen</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+  <style>
+    body {
+      font-family: 'Poppins', sans-serif;
+      background-color: #ffffff;
+      color: #000000;
+    }
+    .nav-link {
+      position: relative;
+      color: #ffffff;
+    }
+    .nav-link::after {
+      content: '';
+      position: absolute;
+      width: 0;
+      height: 2px;
+      bottom: -5px;
+      left: 50%;
+      transform: translateX(-50%);
+      background-color: #ffffff;
+      transition: width 0.3s ease-in-out;
+    }
+    .nav-link:hover::after {
+      width: 100%;
+    }
+    .active-link::after {
+      width: 100%;
+    }
+  </style>
+</head>
+<body class="bg-white text-black">
+
+<header class="bg-[#c50000] sticky top-0 z-50 shadow-md">
+  <div class="container mx-auto px-4">
+    <div class="flex justify-center items-center py-4">
+      <img alt="Master Hijyen Logo" class="h-12" src="assets/images/masterlogo.png"/>
+    </div>
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between py-2 border-t border-red-500">
+      <nav class="hidden md:flex items-center space-x-8 mx-auto">
+        <a class="nav-link" href="index.html">Anasayfa</a>
+        <a class="nav-link" href="hakkimizda.html">Hakkımızda</a>
+        <div class="relative group">
+          <a class="nav-link flex items-center" href="urunler.html">Ürünlerimiz <span class="material-icons text-sm ml-1">expand_more</span></a>
+          <div class="absolute hidden group-hover:block bg-white shadow-lg rounded-md mt-2 py-2 w-56 z-20">
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kagit.html">Kağıt Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kisiselhijyen.html">Kişisel Hijyen</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="gida.html">Gıda Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a>
+          </div>
+        </div>
+        <a class="nav-link" href="#">Blog</a>
+        <a class="nav-link" href="iletisim.html">İletişim</a>
+      </nav>
+      <div class="flex justify-center md:justify-end items-center space-x-4 mt-4 md:mt-0">
+        <a class="hidden md:inline-block px-4 py-2 rounded-md border border-white text-white" href="https://masterhijyen.com/">E-KATALOG</a>
+        <a class="hidden md:inline-block px-4 py-2 rounded-md bg-white text-[#c50000] font-semibold" href="iletisim.html">İLETİŞİME GEÇ</a>
+      </div>
+    </div>
+  </div>
+</header>
+
+<main class="min-h-[400px] py-12">
+  <div class="container mx-auto px-4 space-y-12">
+    <div class="max-w-3xl mx-auto text-center space-y-4">
+      <span class="inline-flex items-center justify-center rounded-full bg-red-100 text-[#c50000] px-3 py-1 text-sm font-medium">Güvenli temas noktaları</span>
+      <h1 class="text-3xl md:text-4xl font-bold text-gray-900">Kişisel Hijyen Grubu</h1>
+      <p class="text-gray-600 text-sm md:text-base">
+        İşletme girişlerinden üretim hatlarına kadar tüm temas noktalarında, hijyen standartlarını yükseltmek için geliştirilmiş sıvı sabun, dezenfektan ve tamamlayıcı ekipman çözümleri sunuyoruz.
+        Tüm ürünlerimiz ulusal ve uluslararası mevzuatlara uygun sertifikalarla desteklenir.
+      </p>
+    </div>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Ürün Gruplarımız</h2>
+        <p class="text-gray-600 text-sm md:text-base">Farklı sektörlerin ihtiyaçlarına yönelik olarak standartlaştırılmış içerik ve ambalajlarla geniş bir ürün portföyü sunuyoruz.</p>
+      </div>
+      <div class="grid gap-6 md:grid-cols-2">
+        <article class="border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition">
+          <h3 class="text-xl font-semibold text-gray-900 mb-2">Alkol Bazlı El Dezenfektanları</h3>
+          <p class="text-gray-600 text-sm md:text-base mb-4">EN 1500 ve EN 12791 standartlarına uygun, %70 ve üzeri alkol içeriğine sahip hızlı kuruyan formüller.</p>
+          <ul class="space-y-1 text-sm text-gray-600">
+            <li>• 500 ml pompalı, 1 L kartuş ve 5 L bidon seçenekleri</li>
+            <li>• Cilt pH'ına uygun nemlendirici katkılar</li>
+            <li>• Turnike ve sensörlü dispenserlerle uyumlu</li>
+          </ul>
+        </article>
+        <article class="border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition">
+          <h3 class="text-xl font-semibold text-gray-900 mb-2">Antibakteriyel Sıvı ve Köpük Sabunlar</h3>
+          <p class="text-gray-600 text-sm md:text-base mb-4">Yoğun kullanımlı alanlar için yüksek köpürme performansı ve kolay durulama sağlayan sabun çeşitleri.</p>
+          <ul class="space-y-1 text-sm text-gray-600">
+            <li>• Dermatolojik olarak test edilmiş formüller</li>
+            <li>• 800 ml torba, 1 L kartuş ve 5 L konsantre</li>
+            <li>• Manuel ve otomatik dispenserlerle uyum</li>
+          </ul>
+        </article>
+        <article class="border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition">
+          <h3 class="text-xl font-semibold text-gray-900 mb-2">Hijyen Mendilleri ve Yüzey Spreyleri</h3>
+          <p class="text-gray-600 text-sm md:text-base mb-4">Kişisel ekipmanlar, klavyeler ve sık dokunulan yüzeylerde hızlı hijyen için alkol bazlı mendil ve spreyler.</p>
+          <ul class="space-y-1 text-sm text-gray-600">
+            <li>• 100'lü kutu, 24'lü travel paket seçenekleri</li>
+            <li>• 750 ml yüzey spreyi ile uyumlu kullanım</li>
+            <li>• HACCP süreçlerine uygun içerik</li>
+          </ul>
+        </article>
+        <article class="border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition">
+          <h3 class="text-xl font-semibold text-gray-900 mb-2">Koruyucu Bariyer Ürünleri</h3>
+          <p class="text-gray-600 text-sm md:text-base mb-4">Eldiven, maske ve tek kullanımlık önlük çözümleriyle üretim ve hizmet alanlarında kişisel korumayı güçlendiriyoruz.</p>
+          <ul class="space-y-1 text-sm text-gray-600">
+            <li>• Nitril, lateks ve vinil seçenekleri</li>
+            <li>• CE belgeli tıbbi maske çeşitleri</li>
+            <li>• Gıda temasına uygun tek kullanımlık önlükler</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Ambalaj ve Dozaj Alternatifleri</h2>
+        <p class="text-gray-600 text-sm md:text-base">Merkezi depolama ve bireysel kullanım alanlarını aynı anda yönetebilmeniz için farklı ambalaj kombinasyonları hazırladık.</p>
+      </div>
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-[#c50000] text-white">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ürün</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Uygulama Alanı</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Ambalaj Seçenekleri</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Öne Çıkan Özellik</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">El Dezenfektanı</td>
+              <td class="px-4 py-3 text-gray-700">Resepsiyon, üretim girişleri, ortak alanlar</td>
+              <td class="px-4 py-3 text-gray-700">500 ml pompalı, 1 L kartuş, 5 L bidon</td>
+              <td class="px-4 py-3 text-gray-700">Hızlı kuruyan jel, gliserin katkılı</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">Sıvı Sabun</td>
+              <td class="px-4 py-3 text-gray-700">Personel lavaboları, ofis tuvaletleri</td>
+              <td class="px-4 py-3 text-gray-700">800 ml torba, 1 L kartuş, 5 L konsantre</td>
+              <td class="px-4 py-3 text-gray-700">Dermatolojik olarak test edilmiş</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">Köpük Sabun</td>
+              <td class="px-4 py-3 text-gray-700">Hızlı su tüketimi hedeflenen alanlar</td>
+              <td class="px-4 py-3 text-gray-700">700 ml torba, 1000 ml kartuş</td>
+              <td class="px-4 py-3 text-gray-700">%50'ye varan su tasarrufu</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">Dezenfektan Mendil</td>
+              <td class="px-4 py-3 text-gray-700">Kiosk, POS cihazı, araç içi kullanım</td>
+              <td class="px-4 py-3 text-gray-700">100'lü dispenser kutu, 24'lü mini paket</td>
+              <td class="px-4 py-3 text-gray-700">İz bırakmayan hızlı kuruyan formül</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Destek ve Danışmanlık</h2>
+        <p class="text-gray-600 text-sm md:text-base">Hijyen standartlarını sürdürülebilir kılmak için ürün tedarikinin ötesinde süreç desteği sağlıyoruz.</p>
+      </div>
+      <div class="grid gap-6 md:grid-cols-3">
+        <div class="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Entegrasyon Planlaması</h3>
+          <p class="text-gray-600 text-sm">Mevcut dispenserlerinize uyumlu kartuş ve montaj aparatı önerileri ile kesintisiz geçiş.</p>
+        </div>
+        <div class="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Eğitim ve Farkındalık</h3>
+          <p class="text-gray-600 text-sm">Personel eğitim setleri, kullanım talimatları ve alan işaretlemeleri ile standartlaşma.</p>
+        </div>
+        <div class="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Tüketim Analizi</h3>
+          <p class="text-gray-600 text-sm">Aylık tüketim raporları ve otomatik sipariş önerileriyle stok güvenliği.</p>
+        </div>
+      </div>
+    </section>
+
+    <div class="bg-red-50 border border-red-200 rounded-2xl p-6 md:flex md:items-center md:justify-between gap-6">
+      <div class="space-y-2">
+        <h3 class="text-xl font-semibold text-[#c50000]">Hijyen protokollerini birlikte şekillendirelim</h3>
+        <p class="text-gray-600 text-sm md:text-base">
+          Kişisel hijyen ürünleri için saha keşfi, numune gönderimi ve tedarik planlaması desteği alabilirsiniz. Uzman ekibimiz sektörünüze özel çözümler üretir.
+        </p>
+      </div>
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3 text-sm font-semibold text-[#c50000]">
+        <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="tel:+905541406565">0554 140 65 65</a>
+        <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="mailto:dogan@masterhijyen.com">dogan@masterhijyen.com</a>
+      </div>
+    </div>
+  </div>
+</main>
+
+<footer class="bg-[#c50000] text-white py-12 mt-16">
+  <div class="container mx-auto px-4">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+      <div>
+        <img src="assets/images/masterlogo.png" alt="Master Hijyen Logo" class="h-12 mb-4">
+        <p class="text-sm">Kişisel hijyen alanlarında sürdürülebilir, güvenli ve ekonomik çözümler sunuyoruz.</p>
+      </div>
+      <div class="grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <h3 class="font-semibold mb-2">Kategorilerimiz</h3>
+          <ul class="space-y-2">
+            <li><a class="hover:underline" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a></li>
+            <li><a class="hover:underline" href="kagit.html">Kağıt Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="kisiselhijyen.html">Kişisel Hijyen</a></li>
+            <li><a class="hover:underline" href="gida.html">Gıda Grubu</a></li>
+            <li><a class="hover:underline" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-semibold mb-2">Kurumsal</h3>
+          <ul class="space-y-1">
+            <li><a class="hover:underline" href="hakkimizda.html">Hakkımızda</a></li>
+            <li><a class="hover:underline" href="iletisim.html">İletişim</a></li>
+            <li><a class="hover:underline" href="#">Blog</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="text-center md:text-right space-y-2">
+        <p class="text-3xl font-bold">4,5<span class="text-lg">/5</span></p>
+        <div class="text-yellow-400">★ ★ ★ ★ ☆</div>
+        <a href="iletisim.html" class="inline-block border border-white text-white px-4 py-2 rounded-full text-sm hover:bg-white hover:text-[#c50000] transition">Hemen Değerlendir</a>
+      </div>
+    </div>
+    <div class="border-t border-white border-opacity-30 mt-8 pt-4 text-center text-sm">
+      Copyright © 2025 Master Hijyen | Tüm hakları saklıdır.
+    </div>
+  </div>
+</footer>
+
+<div class="contact-fab group fixed bottom-5 right-5 z-50">
+  <div class="flex space-x-2 items-center bg-gray-800 text-white px-4 py-2 rounded-full shadow-lg">
+    <a href="tel:+905541406565" class="material-icons" aria-label="Telefon ile ara">call</a>
+    <a href="https://wa.me/905541406565" class="material-icons" aria-label="WhatsApp üzerinden iletişim">whatsapp</a>
+    <a href="mailto:dogan@masterhijyen.com" class="material-icons" aria-label="E-posta gönder">email</a>
+  </div>
+</div>
+
+<script src="main.js"></script>
+</body>
+</html>

--- a/profhijyen.html
+++ b/profhijyen.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Profesyonel Hijyen Ekipmanları | Master Hijyen</title>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+  <style>
+    body {
+      font-family: 'Poppins', sans-serif;
+      background-color: #ffffff;
+      color: #000000;
+    }
+    .nav-link {
+      position: relative;
+      color: #ffffff;
+    }
+    .nav-link::after {
+      content: '';
+      position: absolute;
+      width: 0;
+      height: 2px;
+      bottom: -5px;
+      left: 50%;
+      transform: translateX(-50%);
+      background-color: #ffffff;
+      transition: width 0.3s ease-in-out;
+    }
+    .nav-link:hover::after {
+      width: 100%;
+    }
+    .active-link::after {
+      width: 100%;
+    }
+  </style>
+</head>
+<body class="bg-white text-black">
+
+<header class="bg-[#c50000] sticky top-0 z-50 shadow-md">
+  <div class="container mx-auto px-4">
+    <div class="flex justify-center items-center py-4">
+      <img alt="Master Hijyen Logo" class="h-12" src="assets/images/masterlogo.png"/>
+    </div>
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between py-2 border-t border-red-500">
+      <nav class="hidden md:flex items-center space-x-8 mx-auto">
+        <a class="nav-link" href="index.html">Anasayfa</a>
+        <a class="nav-link" href="hakkimizda.html">Hakkımızda</a>
+        <div class="relative group">
+          <a class="nav-link flex items-center" href="urunler.html">Ürünlerimiz <span class="material-icons text-sm ml-1">expand_more</span></a>
+          <div class="absolute hidden group-hover:block bg-white shadow-lg rounded-md mt-2 py-2 w-56 z-20">
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kagit.html">Kağıt Sanayi Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="kisiselhijyen.html">Kişisel Hijyen</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="gida.html">Gıda Grubu</a>
+            <a class="block px-4 py-2 text-sm text-black hover:bg-gray-100" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a>
+          </div>
+        </div>
+        <a class="nav-link" href="#">Blog</a>
+        <a class="nav-link" href="iletisim.html">İletişim</a>
+      </nav>
+      <div class="flex justify-center md:justify-end items-center space-x-4 mt-4 md:mt-0">
+        <a class="hidden md:inline-block px-4 py-2 rounded-md border border-white text-white" href="https://masterhijyen.com/">E-KATALOG</a>
+        <a class="hidden md:inline-block px-4 py-2 rounded-md bg-white text-[#c50000] font-semibold" href="iletisim.html">İLETİŞİME GEÇ</a>
+      </div>
+    </div>
+  </div>
+</header>
+
+<main class="min-h-[400px] py-12">
+  <div class="container mx-auto px-4 space-y-12">
+    <div class="max-w-3xl mx-auto text-center space-y-4">
+      <span class="inline-flex items-center justify-center rounded-full bg-red-100 text-[#c50000] px-3 py-1 text-sm font-medium">Endüstriyel hijyen yatırımları</span>
+      <h1 class="text-3xl md:text-4xl font-bold text-gray-900">Profesyonel Hijyen Ekipmanları</h1>
+      <p class="text-gray-600 text-sm md:text-base">
+        Üretim alanları, gıda tesisleri, sağlık kuruluşları ve ağır hizmet ortamları için dayanıklı hijyen ekipmanları sağlıyoruz.
+        Mekanik altyapınızla entegre çalışan çözümlerimiz, iş güvenliği ve kalite standartlarını aynı anda garanti eder.
+      </p>
+    </div>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Hijyen İstasyonları ve Kontrol Noktaları</h2>
+        <p class="text-gray-600 text-sm md:text-base">Girişlerde hijyen bariyerleri oluşturarak çapraz kontaminasyon riskini düşüren çözümler.</p>
+      </div>
+      <div class="grid gap-6 md:grid-cols-3">
+        <article class="border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Paslanmaz Hijyen İstasyonları</h3>
+          <p class="text-gray-600 text-sm">Turnike, el yıkama ve kurutma modüllerini tek gövdede sunan IP65 korumalı sistemler.</p>
+          <ul class="text-xs text-gray-600 mt-3 space-y-1">
+            <li>• HACCP ve BRC standartlarına uyum</li>
+            <li>• Otomatik dezenfektan dozajlama</li>
+            <li>• RFID veya kartlı geçiş entegrasyonu</li>
+          </ul>
+        </article>
+        <article class="border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Ayaklı Dezenfektan Standları</h3>
+          <p class="text-gray-600 text-sm">Yoğun insan trafiği olan girişlerde temasız kullanım sağlayan pedallı veya sensörlü seçenekler.</p>
+          <ul class="text-xs text-gray-600 mt-3 space-y-1">
+            <li>• 1 L ve 5 L tank kapasitesi</li>
+            <li>• İç mekân/dış mekân dayanımı</li>
+            <li>• Kurumsal tasarım uygulama imkânı</li>
+          </ul>
+        </article>
+        <article class="border border-gray-200 rounded-2xl p-6 shadow-sm hover:shadow-md transition">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Sensörlü Dispenser Çözümleri</h3>
+          <p class="text-gray-600 text-sm">Sabun, dezenfektan, kağıt havlu ve tuvalet kağıdı dispenserlerinde temassız kullanım.</p>
+          <ul class="text-xs text-gray-600 mt-3 space-y-1">
+            <li>• Li-ion şarjlı ve elektrikli modeller</li>
+            <li>• Hata ve doluluk takibi için IoT altyapısı</li>
+            <li>• ISO 22716 üretim şartlarına uygun</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Profesyonel Makine ve Donanımlar</h2>
+        <p class="text-gray-600 text-sm md:text-base">Geniş metrajlı zeminler ve zorlu yüzeyler için yüksek performanslı makineler sunuyoruz.</p>
+      </div>
+      <div class="overflow-x-auto bg-white border border-gray-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-[#c50000] text-white">
+            <tr>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Makine</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Kullanım Alanı</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Teknik Özellikler</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide">Servis Periyodu</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">Endüstriyel Zemin Otomatı</td>
+              <td class="px-4 py-3 text-gray-700">Gıda üretim alanları, lojistik depoları</td>
+              <td class="px-4 py-3 text-gray-700">90 cm fırça genişliği, 120 L temiz su tankı</td>
+              <td class="px-4 py-3 text-gray-700">3 ayda bir bakım</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">Soğuk Buharlı Dezenfeksiyon Ünitesi</td>
+              <td class="px-4 py-3 text-gray-700">Hastaneler, laboratuvarlar, ambalaj odaları</td>
+              <td class="px-4 py-3 text-gray-700">ULV atomizasyon, 50 mikron damlacık boyutu</td>
+              <td class="px-4 py-3 text-gray-700">6 ayda bir kalibrasyon</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">Endüstriyel Vakum ve Süpürge Sistemleri</td>
+              <td class="px-4 py-3 text-gray-700">Ağır sanayi, talaşlı üretim tesisleri</td>
+              <td class="px-4 py-3 text-gray-700">HEPA filtre, yağ ve talaş ayrıştırıcı modül</td>
+              <td class="px-4 py-3 text-gray-700">Yıllık detaylı bakım</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-semibold text-gray-900">Atık Yönetim Kompaktörleri</td>
+              <td class="px-4 py-3 text-gray-700">AVM, havaalanı ve yüksek hacimli işletmeler</td>
+              <td class="px-4 py-3 text-gray-700">10 m³ sıkıştırma kapasitesi, otomatik uyarı sistemi</td>
+              <td class="px-4 py-3 text-gray-700">6 ayda bir kontrol</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Proje Yönetimi ve Servis</h2>
+        <p class="text-gray-600 text-sm md:text-base">Sadece ekipman tedarik etmekle kalmıyor, işletmenize özel sürdürülebilir hijyen planları oluşturuyoruz.</p>
+      </div>
+      <div class="grid gap-6 md:grid-cols-3">
+        <div class="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Keşif ve Projelendirme</h3>
+          <p class="text-gray-600 text-sm">Saha keşfi sonrası 2D/3D yerleşim planı, enerji ve su altyapısı uyum analizleri.</p>
+        </div>
+        <div class="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Bakım &amp; Yedek Parça</h3>
+          <p class="text-gray-600 text-sm">Yetkili servis ekibimizle periyodik bakım, orijinal parça kullanımı ve 7/24 arıza takibi.</p>
+        </div>
+        <div class="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Operasyon Eğitimi</h3>
+          <p class="text-gray-600 text-sm">Saha ekibiniz için uygulamalı eğitim, kimyasal dozaj ve güvenlik prosedürü danışmanlığı.</p>
+        </div>
+      </div>
+    </section>
+
+    <div class="bg-red-50 border border-red-200 rounded-2xl p-6 md:flex md:items-center md:justify-between gap-6">
+      <div class="space-y-2">
+        <h3 class="text-xl font-semibold text-[#c50000]">Tesisinize özel hijyen yatırım planı</h3>
+        <p class="text-gray-600 text-sm md:text-base">
+          Proje bazlı ekipman kiralama, satın alma ve bakım anlaşmaları için uzmanlarımızla iletişime geçin. Finansal modelleme ve yatırım geri dönüşü hesaplarını birlikte yapalım.
+        </p>
+      </div>
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3 text-sm font-semibold text-[#c50000]">
+        <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="tel:+905541406565">0554 140 65 65</a>
+        <a class="inline-flex items-center justify-center rounded-full border border-[#c50000] px-5 py-2 bg-white hover:bg-[#c50000] hover:text-white transition" href="mailto:dogan@masterhijyen.com">dogan@masterhijyen.com</a>
+      </div>
+    </div>
+  </div>
+</main>
+
+<footer class="bg-[#c50000] text-white py-12 mt-16">
+  <div class="container mx-auto px-4">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+      <div>
+        <img src="assets/images/masterlogo.png" alt="Master Hijyen Logo" class="h-12 mb-4">
+        <p class="text-sm">Endüstriyel hijyen projelerinde uçtan uca çözüm ortağınız.</p>
+      </div>
+      <div class="grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <h3 class="font-semibold mb-2">Kategorilerimiz</h3>
+          <ul class="space-y-2">
+            <li><a class="hover:underline" href="hijyensanayigrubu.html">Hijyen Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="temizlikurunlerigrubu.html">Temizlik Ürünleri Grubu</a></li>
+            <li><a class="hover:underline" href="kagit.html">Kağıt Sanayi Grubu</a></li>
+            <li><a class="hover:underline" href="kisiselhijyen.html">Kişisel Hijyen</a></li>
+            <li><a class="hover:underline" href="gida.html">Gıda Grubu</a></li>
+            <li><a class="hover:underline" href="profhijyen.html">Profesyonel Hijyen Ekipmanları</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-semibold mb-2">Kurumsal</h3>
+          <ul class="space-y-1">
+            <li><a class="hover:underline" href="hakkimizda.html">Hakkımızda</a></li>
+            <li><a class="hover:underline" href="iletisim.html">İletişim</a></li>
+            <li><a class="hover:underline" href="#">Blog</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="text-center md:text-right space-y-2">
+        <p class="text-3xl font-bold">4,5<span class="text-lg">/5</span></p>
+        <div class="text-yellow-400">★ ★ ★ ★ ☆</div>
+        <a href="iletisim.html" class="inline-block border border-white text-white px-4 py-2 rounded-full text-sm hover:bg-white hover:text-[#c50000] transition">Hemen Değerlendir</a>
+      </div>
+    </div>
+    <div class="border-t border-white border-opacity-30 mt-8 pt-4 text-center text-sm">
+      Copyright © 2025 Master Hijyen | Tüm hakları saklıdır.
+    </div>
+  </div>
+</footer>
+
+<div class="contact-fab group fixed bottom-5 right-5 z-50">
+  <div class="flex space-x-2 items-center bg-gray-800 text-white px-4 py-2 rounded-full shadow-lg">
+    <a href="tel:+905541406565" class="material-icons" aria-label="Telefon ile ara">call</a>
+    <a href="https://wa.me/905541406565" class="material-icons" aria-label="WhatsApp üzerinden iletişim">whatsapp</a>
+    <a href="mailto:dogan@masterhijyen.com" class="material-icons" aria-label="E-posta gönder">email</a>
+  </div>
+</div>
+
+<script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the Kağıt Sanayi and Gıda category pages with tables that map the CSV catalogue data into Tailwind-styled listings and refreshed calls to action
- add full content for the Kişisel Hijyen and Profesyonel Hijyen pages, highlighting product groups, packaging options and service offerings
- create an Arama landing page with a search form, CSV-driven quick links and popular product shortcuts plus consistent footer/contact details

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d04a24dc2c832594da37f23c2f5def