### PR TITLE
Add placeholder galleries to product catalog pages

### DIFF
--- a/gida.html
+++ b/gida.html
@@ -80,6 +80,184 @@
       </p>
     </div>
 
+    <div class="space-y-16 mt-12">
+      <section>
+        <div class="max-w-4xl mb-8">
+          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Tek Kullanımlık Karton Bardaklar</h2>
+          <p class="text-gray-600 text-sm md:text-base">
+            Sıcak ve soğuk içecekler için farklı ebat seçenekleri sunan karton bardak çeşitlerimizle servis süreçlerinizi hızlandırın.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 4 oz (50 Adet x 60 Paket)</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 6,5 oz (50 Adet x 40 Paket)</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 7 oz Standart (50 Adet x 40 Paket)</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 7 oz Standart (50 Adet x 30 Paket)</h3>
+            </div>
+          </a>
+        </div>
+      </section>
+
+      <section>
+        <div class="max-w-4xl mb-8">
+          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Şeker ve Karıştırıcılar</h2>
+          <p class="text-gray-600 text-sm md:text-base">
+            Kahve ve çay servislerine eşlik eden şeker ve karıştırıcı seçeneklerimizi ihtiyacınıza göre kolayca seçin.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Tatlı Kaşığı 1000'li Paket</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Irmak Tek Sargılı Küp Şeker</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Sargılı Küp Şeker</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Sargısız Küp Şeker</h3>
+            </div>
+          </a>
+        </div>
+      </section>
+
+      <section>
+        <div class="max-w-4xl mb-8">
+          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Kahve ve Demleme Ürünleri</h2>
+          <p class="text-gray-600 text-sm md:text-base">
+            Ofis ve işletmelerin favorisi olan kahveler, kahve kreması ve demleme ekipmanlarımızı keşfedin.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Nescafé Classic 1000 g Paket</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Filtre Kahve Colombia</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Coffee Time Filtre Kahve Kağıdı No:4</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Nescafé Coffee Mate 400 g</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Nescafé Classic Çözünebilir Kahve 100 g</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Nescafé Gold 100 g</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Mehmet Efendi Türk Kahvesi 100 g</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Mehmet Efendi Türk Kahvesi 250 g</h3>
+            </div>
+          </a>
+        </div>
+      </section>
+
+      <section>
+        <div class="max-w-4xl mb-8">
+          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Çay Çeşitleri</h2>
+          <p class="text-gray-600 text-sm md:text-base">
+            Dökme ve poşet seçenekleriyle demleme alışkanlıklarınıza uygun çayları keşfedin.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Çaykur Tiryaki Dökme Çay 1 Kg</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Çaykur Tiryaki Dökme Çay 1 Kg (Alternatif Paket)</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Çaykur Tiryaki Dökme Çay 500 g</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Doğuş Tiryaki Dökme Çay 1 Kg</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Doğuş Tiryaki Dökme Çay 500 g</h3>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Lipton Delight Yellow Label (100'lü)</h3>
+            </div>
+          </a>
+        </div>
+      </section>
+    </div>
+
     <section class="space-y-6">
       <div class="space-y-2">
         <h2 class="text-2xl font-semibold text-[#c50000]">Şeker ve Tatlandırıcılar</h2>

--- a/kagit.html
+++ b/kagit.html
@@ -80,6 +80,79 @@
       </p>
     </div>
 
+    <div class="space-y-16 mt-12">
+      <section>
+        <div class="max-w-4xl mb-8">
+          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Karton Bardak Vitrini</h2>
+          <p class="text-gray-600 text-sm md:text-base">
+            Stoklarımızda yer alan tüm bardak ölçülerini fotoğraf ekleme alanlarıyla birlikte kolayca planlayın.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 4 Oz</h3>
+              <p class="text-sm text-gray-600">50 adet × 60 paket</p>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 6 Oz</h3>
+              <p class="text-sm text-gray-600">50 adet × 60 paket</p>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 7 Oz Standart</h3>
+              <p class="text-sm text-gray-600">50 adet × 60 paket</p>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 8 Oz</h3>
+              <p class="text-sm text-gray-600">50 adet × 40 paket</p>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Karton Bardak 12 Oz</h3>
+              <p class="text-sm text-gray-600">100 adet × 20 paket</p>
+            </div>
+          </a>
+        </div>
+      </section>
+
+      <section>
+        <div class="max-w-4xl mb-8">
+          <h2 class="text-2xl font-semibold text-[#c50000] mb-2">Karıştırıcı ve Servis Aksesuarları</h2>
+          <p class="text-gray-600 text-sm md:text-base">
+            Görsel yer tutucularını kullanarak yeni fotoğraflarınızı hızlıca eşleyebilirsiniz.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Tahta Karıştırıcı 500'lü</h3>
+              <p class="text-sm text-gray-600">Hızlı tüketim noktaları</p>
+            </div>
+          </a>
+          <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+            <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+            <div class="p-4">
+              <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Tahta Karıştırıcı 1000'li</h3>
+              <p class="text-sm text-gray-600">Ekstra stoklu operasyonlar</p>
+            </div>
+          </a>
+        </div>
+      </section>
+    </div>
+
     <section class="space-y-6">
       <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
         <div class="space-y-2">

--- a/kisiselhijyen.html
+++ b/kisiselhijyen.html
@@ -127,6 +127,43 @@
 
     <section class="space-y-6">
       <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Ürün Vitrini</h2>
+        <p class="text-gray-600 text-sm md:text-base">Fotoğraf ekleme alanları, saha görselleri hazır olduğunda hızlıca güncelleme yapabilmeniz için korunmuştur.</p>
+      </div>
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">El Dezenfektanı 500 ml</h3>
+            <p class="text-sm text-gray-600">Resepsiyon ve üretim girişleri için jel form</p>
+          </div>
+        </a>
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Sıvı Sabun Kartuşu</h3>
+            <p class="text-sm text-gray-600">800 ml torba, 1 L kartuş seçenekleri</p>
+          </div>
+        </a>
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Köpük Sabun</h3>
+            <p class="text-sm text-gray-600">700 ml torba, 1000 ml kartuş</p>
+          </div>
+        </a>
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Dezenfektan Mendil</h3>
+            <p class="text-sm text-gray-600">100'lü dispenser kutu, 24'lü mini paket</p>
+          </div>
+        </a>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
         <h2 class="text-2xl font-semibold text-[#c50000]">Ambalaj ve Dozaj Alternatifleri</h2>
         <p class="text-gray-600 text-sm md:text-base">Merkezi depolama ve bireysel kullanım alanlarını aynı anda yönetebilmeniz için farklı ambalaj kombinasyonları hazırladık.</p>
       </div>

--- a/profhijyen.html
+++ b/profhijyen.html
@@ -118,6 +118,57 @@
 
     <section class="space-y-6">
       <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-[#c50000]">Ürün Vitrini</h2>
+        <p class="text-gray-600 text-sm md:text-base">Profesyonel ekipman fotoğrafları hazır olduğunda kolayca değiştirilebilecek görsel yer tutucular.</p>
+      </div>
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Paslanmaz Hijyen İstasyonu</h3>
+            <p class="text-sm text-gray-600">Turnikeli girişler için tam modül çözümler</p>
+          </div>
+        </a>
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Ayaklı Dezenfektan Standı</h3>
+            <p class="text-sm text-gray-600">Sensörlü ve pedallı modeller</p>
+          </div>
+        </a>
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Endüstriyel Zemin Otomatı</h3>
+            <p class="text-sm text-gray-600">90 cm fırça genişliği, 120 L tank</p>
+          </div>
+        </a>
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Soğuk Buharlı Dezenfeksiyon</h3>
+            <p class="text-sm text-gray-600">ULV atomizasyon, 50 mikron</p>
+          </div>
+        </a>
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Endüstriyel Vakum Sistemi</h3>
+            <p class="text-sm text-gray-600">HEPA filtreli ağır hizmet modelleri</p>
+          </div>
+        </a>
+        <a href="#" class="group block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden">
+          <div class="aspect-square bg-gray-100 flex items-center justify-center text-gray-400 text-xs uppercase tracking-wider">Fotoğraf Eklenecek</div>
+          <div class="p-4 space-y-2">
+            <h3 class="text-base font-semibold text-gray-900 group-hover:text-[#c50000] transition">Atık Yönetim Kompaktörü</h3>
+            <p class="text-sm text-gray-600">10 m³ sıkıştırma kapasitesi</p>
+          </div>
+        </a>
+      </div>
+    </section>
+
+    <section class="space-y-6">
+      <div class="space-y-2">
         <h2 class="text-2xl font-semibold text-[#c50000]">Profesyonel Makine ve Donanımlar</h2>
         <p class="text-gray-600 text-sm md:text-base">Geniş metrajlı zeminler ve zorlu yüzeyler için yüksek performanslı makineler sunuyoruz.</p>
       </div>


### PR DESCRIPTION
## Summary
- restore visual placeholder grids for food catalog items while keeping the new CSV-driven tables intact
- add reusable photo placeholder sections for paper, personal hygiene, and professional hygiene pages so imagery can be supplied later

## Testing
- python3 -m http.server 8000 (manually opened catalog pages via browser script)

------
https://chatgpt.com/codex/tasks/task_e_68d12c0f414c832581fec3b29bd87f5d